### PR TITLE
Feat : 상세페이지 게시글 삭제 기능

### DIFF
--- a/src/main/java/com/project/comgle/controller/PostController.java
+++ b/src/main/java/com/project/comgle/controller/PostController.java
@@ -7,9 +7,7 @@ import com.project.comgle.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,5 +18,10 @@ public class PostController {
     @PostMapping("/posts")
     public ResponseEntity<MessageResponseDto> createPost(@RequestBody PostRequestDto postRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return postService.createPost(postRequestDto, userDetails);
+    }
+
+    @DeleteMapping("/posts/{post-id}")
+    public ResponseEntity<MessageResponseDto> deletePost(@PathVariable("post-id") Long id) {
+        return postService.deletePost(id);
     }
 }

--- a/src/main/java/com/project/comgle/repository/KeywordRepository.java
+++ b/src/main/java/com/project/comgle/repository/KeywordRepository.java
@@ -1,0 +1,14 @@
+package com.project.comgle.repository;
+
+import com.project.comgle.entity.Keyword;
+import com.project.comgle.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+
+    List<Keyword> findAllByPost(Post post);
+
+}

--- a/src/main/java/com/project/comgle/service/PostService.java
+++ b/src/main/java/com/project/comgle/service/PostService.java
@@ -2,23 +2,25 @@ package com.project.comgle.service;
 
 import com.project.comgle.dto.request.PostRequestDto;
 import com.project.comgle.dto.response.MessageResponseDto;
-import com.project.comgle.entity.Category;
-import com.project.comgle.entity.Keyword;
-import com.project.comgle.entity.Post;
-import com.project.comgle.entity.PostCategory;
+import com.project.comgle.entity.*;
+import com.project.comgle.entity.enumSet.PositionEnum;
 import com.project.comgle.repository.CategoryRepository;
+import com.project.comgle.repository.KeywordRepository;
 import com.project.comgle.repository.PostCategoryRepository;
 import com.project.comgle.repository.PostRepository;
 import com.project.comgle.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.apache.catalina.User;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +29,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final CategoryRepository categoryRepository;
     private final PostCategoryRepository postCategoryRepository;
+    private final KeywordRepository keywordRepository;
 
     @Transactional
     public ResponseEntity<MessageResponseDto> createPost(PostRequestDto postRequestDto, UserDetailsImpl userDetails) {
@@ -45,7 +48,30 @@ public class PostService {
         PostCategory postCategory = PostCategory.of(category, newPost);
         postCategoryRepository.save(postCategory);
 
-        return ResponseEntity.ok().body(MessageResponseDto.of(HttpStatus.OK.value(), "게시글 작성 성공"));
+        return ResponseEntity.ok().body(MessageResponseDto.of(HttpStatus.OK.value(), "작성 완료"));
+    }
+
+
+    @Transactional
+    public ResponseEntity<MessageResponseDto> deletePost(Long id) {
+        Optional<Post> post = postRepository.findById(id);
+        if (post.isEmpty()) {
+            throw new IllegalArgumentException("해당 게시글이 없습니다.");
+        }
+
+        List<Keyword> keywordList = keywordRepository.findAllByPost(post.get());
+        for (Keyword k : keywordList) {
+            keywordRepository.delete(k);
+        }
+
+        Optional<PostCategory> postCategory = postCategoryRepository.findById(post.get().getId());
+        if(postCategory.isPresent()){
+            postCategoryRepository.delete(postCategory.get());
+            categoryRepository.deleteById(postCategory.get().getCategory().getId());
+        }
+        postRepository.delete(post.get());
+
+        return ResponseEntity.ok().body(MessageResponseDto.of(HttpStatus.OK.value(), "삭제 완료"));
     }
 
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/29/deletePost-> develop

### 변경 사항
- Post와 해당 post에 연결된 keyword, category, postCategory 함께 삭제됩니다.

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
