### PR TITLE
Fix : 회원 가입 시 이메일 중복 관련 이슈 (#64)

### DIFF
--- a/src/main/java/com/project/comgle/config/WebSecurityConfig.java
+++ b/src/main/java/com/project/comgle/config/WebSecurityConfig.java
@@ -60,6 +60,7 @@ public class WebSecurityConfig {
 
         http.authorizeRequests() //  요청에 대한 보안 검사를 구성한다.
                 .antMatchers("/login").permitAll()
+                .antMatchers("/check/email/**").permitAll()
                 .anyRequest().authenticated() // 나머지 URL에 대한 접근 권한을 설정합니다. 인증된 사용자만 접근할 수 있다.
                 // JWT 인증/인가를 사용하기 위한 설정
                 // JwtAuthFilter를 UsernamePasswordAuthenticationFilter 이전에 실행되도록 설정한다. JwtAuthFilter는 JWT 토큰을 검증하고 인증/인가를 처리한다.

--- a/src/main/java/com/project/comgle/controller/AdminController.java
+++ b/src/main/java/com/project/comgle/controller/AdminController.java
@@ -21,7 +21,7 @@ public class AdminController {
 
     @PostMapping("/signup")
     public ResponseEntity<MessageResponseDto> signup(@Valid @RequestBody SignupRequestDto signupRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return adminService.signup(signupRequestDto, userDetails.getUser());
+        return adminService.signup(signupRequestDto, userDetails.getMember());
     }
 
     @PutMapping("/position/members/{member-id}")
@@ -30,14 +30,14 @@ public class AdminController {
     }
 
     @GetMapping("/check/email/{email}")
-    public ResponseEntity<MessageResponseDto> checkEmail(@PathVariable String email, @AuthenticationPrincipal UserDetailsImpl userDetails ){
-        adminService.checkEmail(email,userDetails.getUser().getCompany());
+    public ResponseEntity<MessageResponseDto> checkEmail(@PathVariable String email){
+        adminService.checkEmail(email);
         return ResponseEntity.ok(MessageResponseDto.of(HttpStatus.OK.value(),"사용 가능합니다."));
     }
 
     @GetMapping("/check/name/{member-name}")
     public ResponseEntity<MessageResponseDto> checkName(@PathVariable(name = "member-name") String memberName, @AuthenticationPrincipal UserDetailsImpl userDetails){
-        adminService.checkName(memberName,userDetails.getUser().getCompany());
+        adminService.checkName(memberName,userDetails.getMember().getCompany());
         return ResponseEntity.ok(MessageResponseDto.of(HttpStatus.OK.value(),"사용 가능합니다."));
     }
 

--- a/src/main/java/com/project/comgle/repository/MemberRepository.java
+++ b/src/main/java/com/project/comgle/repository/MemberRepository.java
@@ -12,8 +12,6 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
 
     Optional<Member> findByEmail(String email);
 
-    Optional<Member> findByEmailAndCompany(String email,Company company);
-
     Optional<Member> findByMemberNameAndCompany(String memberName,Company company);
 
     List<Member> findAllByCompany(Company company);

--- a/src/main/java/com/project/comgle/service/AdminService.java
+++ b/src/main/java/com/project/comgle/service/AdminService.java
@@ -64,7 +64,7 @@ public class AdminService {
         }
 
         checkName(signupRequestDto.getMemberName(),company);
-        checkEmail(signupRequestDto.getEmail(),company);
+        checkEmail(signupRequestDto.getEmail());
 
         Member newMember = Member.of(signupRequestDto,password,position,company);
         memberRepository.save(newMember);
@@ -72,9 +72,9 @@ public class AdminService {
     }
 
     @Transactional(readOnly = true)
-    public void checkEmail(String email,Company company){
+    public void checkEmail(String email){
 
-        Optional<Member> findMember = memberRepository.findByEmailAndCompany(email, company);
+        Optional<Member> findMember = memberRepository.findByEmail(email);
 
         if(findMember.isPresent()){
             throw new IllegalArgumentException("중복된 이메일이 존재합니다.");


### PR DESCRIPTION
- 모든 회사에 대해서 서로 다른 이메일 사용

### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/64/change-valid-email -> develop

### 변경 사항
- 서로 다른 회사라도 동일한 이메일 사용 금지
- 이메일 중복 확인 부분 변경
- Admin domain getUser() -> getMember()로 변경

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
