### PR TITLE
Feat : 중요도 순 검색 결과 정렬 #100

### DIFF
--- a/src/main/java/com/project/comgle/dto/response/PostResponseDto.java
+++ b/src/main/java/com/project/comgle/dto/response/PostResponseDto.java
@@ -36,11 +36,10 @@ public class PostResponseDto {
     @Schema(description = SchemaDescriptionUtils.Keyword.NAME)
     private String[] keywords;
 
-
-    //    List<Comment> comments;
+    private int postViews;
 
     @Builder
-    private PostResponseDto(Long id, String memberName, String title, String content, LocalDateTime createdAt, LocalDateTime modifiedAt, String category, String[] keywords) {
+    private PostResponseDto(Long id, String memberName, String title, String content, LocalDateTime createdAt, LocalDateTime modifiedAt, String category, String[] keywords, int postViews) {
         this.id = id;
         this.memberName = memberName;
         this.title = title;
@@ -48,8 +47,8 @@ public class PostResponseDto {
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
         this.category = category;
-//        this.comments= comments;
         this.keywords = keywords;
+        this.postViews = postViews;
     }
 
     public static PostResponseDto of(Post post, String category, String[] keywords) {
@@ -62,6 +61,20 @@ public class PostResponseDto {
                 .modifiedAt(post.getModifiedAt())
                 .category(category)
                 .keywords(keywords)
+                .build();
+    }
+
+    public static PostResponseDto of(Post post, String category, String[] keywords, int postViews) {
+        return PostResponseDto.builder()
+                .id(post.getId())
+                .memberName(post.getMember().getMemberName())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .modifiedAt(post.getModifiedAt())
+                .category(category)
+                .keywords(keywords)
+                .postViews(postViews)
                 .build();
     }
 }

--- a/src/main/java/com/project/comgle/entity/Post.java
+++ b/src/main/java/com/project/comgle/entity/Post.java
@@ -27,6 +27,12 @@ public class Post extends Timestamped {
     @Column(nullable = false, columnDefinition = "MEDIUMTEXT")
     private String content;
 
+    @Column(nullable = false)
+    private int postViews = 0;
+
+    @Column(nullable = false)
+    private int score = 0;
+
     @Enumerated(EnumType.STRING)
     private PositionEnum modifyPermission;
 
@@ -49,7 +55,7 @@ public class Post extends Timestamped {
     private List<Comment> comments = new ArrayList<>();
 
     @Builder
-    private Post(String title, String content, PositionEnum modifyPermission, PositionEnum readablePosition, Member member,Category category, List<Comment> comments) {
+    private Post(String title, String content, PositionEnum modifyPermission, PositionEnum readablePosition, Member member,Category category, List<Comment> comments, int postViews, int score) {
         this.title = title;
         this.content = content;
         this.modifyPermission = modifyPermission;
@@ -57,6 +63,8 @@ public class Post extends Timestamped {
         this.category = category;
         this.member = member;
         this.comments = comments;
+        this.postViews = postViews;
+        this.score = score;
     }
 
     public static Post from(PostRequestDto postRequestDto, Category category,Member member){
@@ -74,6 +82,11 @@ public class Post extends Timestamped {
         this.title = postRequestDto.getTitle();
         this.content = postRequestDto.getContent();
         this.category = category;
+    }
+
+    public void updateMethod(int weight) {
+        this.postViews += (weight==3) ? 1 : 0;
+        this.score += weight;
     }
 
 }

--- a/src/main/java/com/project/comgle/entity/WeightEnum.java
+++ b/src/main/java/com/project/comgle/entity/WeightEnum.java
@@ -1,0 +1,16 @@
+package com.project.comgle.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum WeightEnum {
+    BOOKMARK(5),
+    POSTVIEWS(3),
+    COMMENTCOUNT(1);
+
+    private int num;
+
+    WeightEnum(int num) {
+        this.num = num;
+    }
+}

--- a/src/main/java/com/project/comgle/repository/BookMarkRepository.java
+++ b/src/main/java/com/project/comgle/repository/BookMarkRepository.java
@@ -1,6 +1,7 @@
 package com.project.comgle.repository;
 
 import com.project.comgle.entity.BookMark;
+import com.project.comgle.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,4 +10,5 @@ import java.util.Optional;
 public interface BookMarkRepository extends JpaRepository<BookMark, Long> {
     Optional<BookMark> findByBookMarkFolderIdAndPostId(Long folderId, Long postId);
     List<BookMark> findAllByBookMarkFolderId(Long folderId);
+
 }

--- a/src/main/java/com/project/comgle/repository/KeywordRepository.java
+++ b/src/main/java/com/project/comgle/repository/KeywordRepository.java
@@ -11,6 +11,6 @@ public interface KeywordRepository extends JpaRepository<Keyword, Long> {
 
     List<Keyword> findAllByPost(Post post);
 
-    List<Keyword> findAllByKeyword(String keyword);
+    List<Keyword> findAllByKeywordContains(String keyword);
     void deleteAllByPost(Post post);
 }

--- a/src/main/java/com/project/comgle/repository/PostRepository.java
+++ b/src/main/java/com/project/comgle/repository/PostRepository.java
@@ -18,4 +18,7 @@ public interface PostRepository extends JpaRepository<Post,Long> {
 
     Set<Post> findAllByTitleContainsOrContentContaining(String title,String content);
 
+
+
+
 }

--- a/src/main/java/com/project/comgle/service/BookMarkService.java
+++ b/src/main/java/com/project/comgle/service/BookMarkService.java
@@ -139,6 +139,8 @@ public class BookMarkService {
         BookMark newBookMark = BookMark.of(findMember.get(), findPost.get(), findBookMarkFolder.get());
         bookMarkRepository.save(newBookMark);
 
+        findPost.get().updateMethod(WeightEnum.BOOKMARK.getNum());
+
         return SuccessResponse.of(HttpStatus.CREATED, "Register BookMark");
     }
 

--- a/src/main/java/com/project/comgle/service/CommentService.java
+++ b/src/main/java/com/project/comgle/service/CommentService.java
@@ -5,6 +5,7 @@ import com.project.comgle.dto.response.CommentResponseDto;
 import com.project.comgle.dto.response.MessageResponseDto;
 import com.project.comgle.entity.Comment;
 import com.project.comgle.entity.Post;
+import com.project.comgle.entity.WeightEnum;
 import com.project.comgle.exception.CustomException;
 import com.project.comgle.exception.ExceptionEnum;
 import com.project.comgle.repository.CommentRepository;
@@ -45,6 +46,8 @@ public class CommentService {
 
         // 댓글 DB 저장
         commentRepository.save(comment);
+
+        findPost.get().updateMethod(WeightEnum.COMMENTCOUNT.getNum());
 
         return ResponseEntity.ok(MessageResponseDto.of(HttpStatus.OK.value(), "Add Comment Successfully"));
     }

--- a/src/main/java/com/project/comgle/service/SearchService.java
+++ b/src/main/java/com/project/comgle/service/SearchService.java
@@ -2,11 +2,7 @@ package com.project.comgle.service;
 
 import com.project.comgle.dto.response.SearchResponseDto;
 import com.project.comgle.entity.*;
-import com.project.comgle.exception.ExceptionEnum;
-import com.project.comgle.repository.CategoryRepository;
-import com.project.comgle.repository.CommentRepository;
-import com.project.comgle.repository.KeywordRepository;
-import com.project.comgle.repository.PostRepository;
+import com.project.comgle.repository.*;
 import kr.co.shineware.nlp.komoran.constant.DEFAULT_MODEL;
 import kr.co.shineware.nlp.komoran.core.Komoran;
 import kr.co.shineware.nlp.komoran.model.KomoranResult;
@@ -18,6 +14,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -28,6 +28,7 @@ public class SearchService {
 
     private final CommentRepository commentRepository;
     private final CategoryRepository categoryRepository;
+    private final BookMarkRepository bookMarkRepository;
 
     @Transactional
     public List<SearchResponseDto> searchKeyword(String keyword, Company company) {
@@ -37,26 +38,27 @@ public class SearchService {
 
         // title, content, keyword가 포함 된 게시글 찾기
         for (String key : keywords) {
-            postList.addAll(postRepository.findAllByTitleContainsOrContentContaining(key,key));
-            List<Keyword> findKeyWords = keywordRepository.findAllByKeyword(key);
+            postList.addAll(postRepository.findAllByTitleContainsOrContentContaining(key, key));
+            List<Keyword> findKeyWords = keywordRepository.findAllByKeywordContains(key);
             for (Keyword k : findKeyWords) {
                 postList.add(k.getPost());
             }
         }
 
-        log.info("list post size = {}" ,postList.size());
+        log.info("list post size = {}", postList.size());
         Set<Post> allPosts = new HashSet<>(postList);
-        log.info("set post size = {}" ,allPosts.size());
+        log.info("set post size = {}", allPosts.size());
 
         // 해당 회사 게시글만 조회하기
         List<Post> companyPost = allPosts.stream().filter(p -> Objects.equals(p.getCategory().getCompany().getId(), company.getId())).collect(Collectors.toList());
-        log.info("filter company post size = {}" ,companyPost.size());
+        log.info("filter company post size = {}", companyPost.size());
+        Collections.sort(companyPost, Comparator.comparingInt(Post::getScore).reversed());
 
         List<SearchResponseDto> searchResponseDtoList = new ArrayList<>();
         for (Post post : companyPost) {
             List<Keyword> keywords2 = post.getKeywords();
             String[] keywordList = new String[keywords2.size()];
-            for (int i=0; i < keywords2.size(); i++) {
+            for (int i = 0; i < keywords2.size(); i++) {
                 keywordList[i] = keywords2.get(i).getKeyword();
             }
 
@@ -69,7 +71,6 @@ public class SearchService {
     }
 
 
-
     @Transactional
     public List<SearchResponseDto> searchCategory(String category, Member member) {
 
@@ -78,13 +79,13 @@ public class SearchService {
             throw new IllegalArgumentException("해당 카테고리의 게시물이 없습니다.");
         }
         List<Post> findPosts = postRepository.findAllByCategoryId(findCategory.get().getId());
-
+        Collections.sort(findPosts, Comparator.comparingInt(Post::getScore).reversed());
 
         List<SearchResponseDto> searchResponseDtoList = new ArrayList<>();
         for (Post post : findPosts) {
             List<Keyword> keywords = post.getKeywords();
             String[] keywordList = new String[keywords.size()];
-            for (int i=0; i < keywords.size(); i++) {
+            for (int i = 0; i < keywords.size(); i++) {
                 keywordList[i] = keywords.get(i).getKeyword();
             }
 
@@ -104,8 +105,10 @@ public class SearchService {
         KomoranResult result = komoran.analyze(keyword);
 
         List<String> nouns = result.getNouns();
-        log.info( "search keywords = {}", String.join(", " , nouns));
+        log.info("search keywords = {}", String.join(", ", nouns));
         return nouns;
     }
+
+
 }
 


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/100/searchScore-> dev

### 변경 사항
- post에 조회수, 가중치 column 추가
- 즐겨찾기 수, 조회수, 댓글 수 순으로 가중치를 Enum으로 적용하여 점수를 매기고, 내림차순으로 정렬해서 response

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
