### PR TITLE
Refactor : 관리자, 카테고리 도메인 예외처리 적용 (#105)

### DIFF
--- a/src/main/java/com/project/comgle/config/WebSecurityConfig.java
+++ b/src/main/java/com/project/comgle/config/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.project.comgle.config;
 
+import com.project.comgle.exception.CustomAccessDeniedHandler;
 import com.project.comgle.jwt.JwtAuthFilter;
 import com.project.comgle.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,8 @@ import java.util.Arrays;
 @EnableGlobalMethodSecurity(securedEnabled = true)
 public class WebSecurityConfig {
     private final JwtUtil jwtUtil;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -62,16 +65,17 @@ public class WebSecurityConfig {
 
         http.authorizeRequests() //  요청에 대한 보안 검사를 구성한다.
                 .antMatchers("/login").permitAll()
-                .antMatchers("/check/email/**").permitAll()
+                .antMatchers("/check/**/**").permitAll()
                 .anyRequest().authenticated() // 나머지 URL에 대한 접근 권한을 설정합니다. 인증된 사용자만 접근할 수 있다.
                 // JWT 인증/인가를 사용하기 위한 설정
                 // JwtAuthFilter를 UsernamePasswordAuthenticationFilter 이전에 실행되도록 설정한다. JwtAuthFilter는 JWT 토큰을 검증하고 인증/인가를 처리한다.
                 .and().addFilterBefore(new JwtAuthFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
+        http.exceptionHandling().accessDeniedHandler(customAccessDeniedHandler);
 //        http.formLogin().loginPage("/api/user/login-page").permitAll(); //로그인 페이지를 설정한다
-//
-//        http.exceptionHandling().accessDeniedPage("/api/user/forbidden");
 
         return http.build();
     }
+
+
 }

--- a/src/main/java/com/project/comgle/config/WebSecurityConfig.java
+++ b/src/main/java/com/project/comgle/config/WebSecurityConfig.java
@@ -65,7 +65,7 @@ public class WebSecurityConfig {
 
         http.authorizeRequests() //  요청에 대한 보안 검사를 구성한다.
                 .antMatchers("/login").permitAll()
-                .antMatchers("/check/**/**").permitAll()
+                .antMatchers("/check/**").permitAll()
                 .anyRequest().authenticated() // 나머지 URL에 대한 접근 권한을 설정합니다. 인증된 사용자만 접근할 수 있다.
                 // JWT 인증/인가를 사용하기 위한 설정
                 // JwtAuthFilter를 UsernamePasswordAuthenticationFilter 이전에 실행되도록 설정한다. JwtAuthFilter는 JWT 토큰을 검증하고 인증/인가를 처리한다.

--- a/src/main/java/com/project/comgle/controller/AdminController.java
+++ b/src/main/java/com/project/comgle/controller/AdminController.java
@@ -1,15 +1,16 @@
 package com.project.comgle.controller;
 
+import com.project.comgle.dto.common.SuccessResponse;
 import com.project.comgle.dto.request.PositionRequestDto;
 import com.project.comgle.dto.request.SignupRequestDto;
-import com.project.comgle.dto.response.MessageResponseDto;
+import com.project.comgle.entity.enumSet.PositionEnum;
 import com.project.comgle.security.UserDetailsImpl;
 import com.project.comgle.service.AdminService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,37 +23,36 @@ public class AdminController {
 
     private final AdminService adminService;
 
-
     @Operation(summary = "회원가입 API", description = "회원을 등록합니다.")
     @ResponseStatus(value = HttpStatus.OK)
+    @Secured(PositionEnum.Authority.ADMIN)
     @PostMapping("/signup")
-    public ResponseEntity<MessageResponseDto> signup(@Valid @RequestBody SignupRequestDto signupRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public SuccessResponse signup(@Valid @RequestBody SignupRequestDto signupRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return adminService.signup(signupRequestDto, userDetails.getMember());
     }
 
     @Operation(summary = "직책변경 API", description = "회원의 직책을 변경합니다.")
     @ResponseStatus(value = HttpStatus.OK)
-    @PutMapping("/position/members/{member-id}")
-    public MessageResponseDto updatePosition(@PathVariable(name = "member-id") Long memberId, @RequestBody PositionRequestDto positionRequestDto){
+    @Secured(PositionEnum.Authority.ADMIN)
+    @PutMapping("/member/{member-id}/position")
+    public SuccessResponse updatePosition(@PathVariable(name = "member-id") Long memberId, @RequestBody PositionRequestDto positionRequestDto){
         return adminService.updatePosition(memberId, positionRequestDto.getPosition());
     }
-
 
     @Operation(summary = "Email 중복 확인 API", description = "회원가입 시 Email 중복 확인합니다.")
     @ResponseStatus(value = HttpStatus.OK)
     @GetMapping("/check/email/{email}")
-    public ResponseEntity<MessageResponseDto> checkEmail(@PathVariable String email){
+    public SuccessResponse checkEmail(@PathVariable String email){
         adminService.checkEmail(email);
-        return ResponseEntity.ok(MessageResponseDto.of(HttpStatus.OK.value(),"사용 가능합니다."));
+        return SuccessResponse.of(HttpStatus.OK,"사용 가능합니다.");
     }
-
 
     @Operation(summary = "회원명 중복 확인 API", description = "회원가입 시 회원명 중복 확인합니다.")
     @ResponseStatus(value = HttpStatus.OK)
     @GetMapping("/check/name/{member-name}")
-    public ResponseEntity<MessageResponseDto> checkName(@PathVariable(name = "member-name") String memberName, @AuthenticationPrincipal UserDetailsImpl userDetails){
+    public SuccessResponse checkName(@PathVariable(name = "member-name") String memberName, @AuthenticationPrincipal UserDetailsImpl userDetails){
         adminService.checkName(memberName,userDetails.getMember().getCompany());
-        return ResponseEntity.ok(MessageResponseDto.of(HttpStatus.OK.value(),"사용 가능합니다."));
+        return SuccessResponse.of(HttpStatus.OK,"사용 가능합니다.");
     }
 
 }

--- a/src/main/java/com/project/comgle/controller/CategoryController.java
+++ b/src/main/java/com/project/comgle/controller/CategoryController.java
@@ -1,21 +1,18 @@
 package com.project.comgle.controller;
 
-import com.project.comgle.dto.common.ErrorResponse;
+import com.project.comgle.dto.common.SuccessResponse;
 import com.project.comgle.dto.request.CategoryRequestDto;
 import com.project.comgle.dto.response.CategoryResponseDto;
-import com.project.comgle.dto.response.MessageResponseDto;
+import com.project.comgle.entity.enumSet.PositionEnum;
 import com.project.comgle.security.UserDetailsImpl;
 import com.project.comgle.service.CategoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -27,20 +24,13 @@ import java.util.List;
 @Tag(name = "CATEGORY", description = "카테고리 관련 API Document")
 public class CategoryController {
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ResponseEntity<ErrorResponse> validException(BindingResult result){
-        log.error("error msg = {}",result.getFieldError().getDefaultMessage());
-        return ResponseEntity.badRequest()
-                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), result.getFieldError().getDefaultMessage()));
-    }
-
     private final CategoryService categoryService;
 
     @Operation(summary = "카테고리 생성 API", description = "ADMIN PAGE에서 사내 카테고리를 생성합니다.")
     @ResponseStatus(value = HttpStatus.OK)
+    @Secured(PositionEnum.Authority.ADMIN)
     @PostMapping("/category")
-    public MessageResponseDto createCategory(@Valid @RequestBody CategoryRequestDto categoryRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails){
+    public SuccessResponse createCategory(@Valid @RequestBody CategoryRequestDto categoryRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails){
         return categoryService.create(categoryRequestDto.getCategoryName().trim(), userDetails.getMember(), userDetails.getCompany());
     }
 
@@ -53,17 +43,19 @@ public class CategoryController {
 
     @Operation(summary = "카테고리 수정 API", description = "ADMIN PAGE에서 사내 해당 카테고리를 수정합니다.")
     @ResponseStatus(value = HttpStatus.OK)
+    @Secured(PositionEnum.Authority.ADMIN)
     @PutMapping("/category/{category-id}")
-    public MessageResponseDto update( @PathVariable(name = "category-id") Long categoryId,
+    public SuccessResponse update( @PathVariable(name = "category-id") Long categoryId,
                                       @Valid @RequestBody CategoryRequestDto categoryRequestDto,
                                       @AuthenticationPrincipal UserDetailsImpl userDetails){
-        return categoryService.updateCategory(categoryId, categoryRequestDto.getCategoryName() ,userDetails);
+        return categoryService.updateCategory(categoryId, categoryRequestDto.getCategoryName(), userDetails.getMember(), userDetails.getCompany());
     }
 
     @Operation(summary = "카테고리 삭제 API", description = "ADMIN PAGE에서 사내 해당 카테고리를 삭제합니다.")
     @ResponseStatus(value = HttpStatus.OK)
-    @DeleteMapping("/categories/{category-id}")
-    public MessageResponseDto delete(@PathVariable(name = "category-id") Long categoryId, @AuthenticationPrincipal UserDetailsImpl userDetails){
-        return categoryService.deleteCategory(categoryId, userDetails.getMember());
+    @Secured(PositionEnum.Authority.ADMIN)
+    @DeleteMapping("/category/{category-id}")
+    public SuccessResponse delete(@PathVariable(name = "category-id") Long categoryId, @AuthenticationPrincipal UserDetailsImpl userDetails){
+        return categoryService.deleteCategory(categoryId, userDetails.getMember(), userDetails.getCompany());
     }
 }

--- a/src/main/java/com/project/comgle/controller/MemberController.java
+++ b/src/main/java/com/project/comgle/controller/MemberController.java
@@ -30,13 +30,6 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> validException(BindingResult result){
-        log.error("error msg = {}",result.getFieldError().getDefaultMessage());
-        return ResponseEntity.badRequest()
-                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), result.getFieldError().getDefaultMessage()));
-    }
-
     @Operation(summary = "회사 등록 API", description = "서비스에 해당 회사를 등록합니다")
     @ResponseStatus(value = HttpStatus.OK)
     @PostMapping("/company")
@@ -55,6 +48,6 @@ public class MemberController {
     @ResponseStatus(value = HttpStatus.OK)
     @GetMapping("/members")
     public List<MemberResponseDto> getMembers(@AuthenticationPrincipal UserDetailsImpl userDetails){
-        return memberService.findMembers(userDetails.getUser());
+        return memberService.findMembers(userDetails.getMember());
     }
 }

--- a/src/main/java/com/project/comgle/controller/PostController.java
+++ b/src/main/java/com/project/comgle/controller/PostController.java
@@ -20,14 +20,12 @@ public class PostController {
 
     private final PostService postService;
 
-
     @Operation(summary = "게시글 작성 API", description = "게시글을 작성합니다.")
     @ResponseStatus(value = HttpStatus.OK)
     @PostMapping("/posts")
     public ResponseEntity<MessageResponseDto> createPost(@RequestBody PostRequestDto postRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return postService.createPost(postRequestDto, userDetails);
     }
-
 
     @Operation(summary = "게시글 삭제 API", description = "해당 게시글을 삭제합니다.")
     @ResponseStatus(value = HttpStatus.OK)
@@ -36,14 +34,12 @@ public class PostController {
         return postService.deletePost(id, userDetails.getMember());
     }
 
-
     @Operation(summary = "게시글 수정 API", description = "해당 게시글을 수정합니다.")
     @ResponseStatus(value = HttpStatus.OK)
     @PutMapping("/post/{post-id}")
     public ResponseEntity<MessageResponseDto> updatePost(@PathVariable("post-id") Long id, @RequestBody PostRequestDto postRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return postService.updatePost(id, postRequestDto, userDetails.getUser());
+        return postService.updatePost(id, postRequestDto, userDetails.getMember());
     }
-
 
     @Operation(summary = "게시글 조회 API", description = "상세보기 PAGE를 위해 해당 게시글을 조회합니다.")
     @ResponseStatus(value = HttpStatus.OK)

--- a/src/main/java/com/project/comgle/controller/SearchController.java
+++ b/src/main/java/com/project/comgle/controller/SearchController.java
@@ -1,10 +1,10 @@
 package com.project.comgle.controller;
 
-import com.project.comgle.dto.response.PostResponseDto;
 import com.project.comgle.dto.response.SearchResponseDto;
 import com.project.comgle.security.UserDetailsImpl;
 import com.project.comgle.service.SearchService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,6 +17,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "SEARCH", description = "게시글 조건 조회 관련 API Document")
 public class SearchController {
 
     private final SearchService searchService;

--- a/src/main/java/com/project/comgle/dto/request/PositionRequestDto.java
+++ b/src/main/java/com/project/comgle/dto/request/PositionRequestDto.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public class PositionRequestDto {
 
     @Schema(description = SchemaDescriptionUtils.Member.POSITION,
-            example = "MEMBER", allowableValues = {"MEMEBER", "MANAGER","OWNER"})
+            example = "MEMBER", allowableValues = {"MEM" +
+            "BER", "MANAGER","OWNER"})
     private String position;
 }

--- a/src/main/java/com/project/comgle/entity/Category.java
+++ b/src/main/java/com/project/comgle/entity/Category.java
@@ -23,16 +23,17 @@ public class Category {
     @JoinColumn(name = "COMPANY_ID", nullable = false)
     private Company company;
 
-    //Post 담당자와 추후 협의할 사항
     @Builder
-    public Category(String categoryName) {
-        this.categoryName = categoryName;
-    }
-
-    @Builder
-    public Category(String categoryName, Company company) {
+    private Category(String categoryName, Company company) {
         this.categoryName = categoryName;
         this.company = company;
+    }
+
+    public static Category of(String categoryName, Company company){
+        return Category.builder()
+                .categoryName(categoryName)
+                .company(company)
+                .build();
     }
 
     public void update(String categoryName){

--- a/src/main/java/com/project/comgle/entity/enumSet/PositionEnum.java
+++ b/src/main/java/com/project/comgle/entity/enumSet/PositionEnum.java
@@ -4,14 +4,28 @@ import lombok.Getter;
 
 @Getter
 public enum PositionEnum {
-    ADMIN(3),
-    OWNER(2),
-    MANAGER(1),
-    MEMBER(0);
+    ADMIN(Authority.ADMIN_NUM,Authority.ADMIN),
+    OWNER(Authority.OWNER_NUM,Authority.OWNER),
+    MANAGER(Authority.MANAGER_NUM,Authority.MANAGER),
+    MEMBER(Authority.MEMBER_NUM,Authority.MEMBER);
 
-    private int num;
+    private final int num;
+    private final String authority;
 
-    PositionEnum(int num) {
+    PositionEnum(int num, String authority) {
         this.num = num;
+        this.authority = authority;
+    }
+
+    public static class Authority {
+        public static final String ADMIN = "ROLE_ADMIN";
+        public static final String OWNER = "ROLE_OWNER";
+        public static final String MANAGER = "ROLE_MANAGER";
+        public static final String MEMBER = "ROLE_MEMBER";
+
+        public static final int ADMIN_NUM = 3;
+        public static final int OWNER_NUM = 2;
+        public static final int MANAGER_NUM = 1;
+        public static final int MEMBER_NUM = 0;
     }
 }

--- a/src/main/java/com/project/comgle/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/project/comgle/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package com.project.comgle.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.comgle.dto.common.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    private static final ErrorResponse exceptionDto =
+            ErrorResponse.of(HttpStatus.FORBIDDEN.value(), ExceptionEnum.REQUIRED_ADMIN_POSITION.getMsg());
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+
+        try (OutputStream os = response.getOutputStream()) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.writeValue(os, exceptionDto);
+            os.flush();
+        }
+    }
+}

--- a/src/main/java/com/project/comgle/exception/ExceptionEnum.java
+++ b/src/main/java/com/project/comgle/exception/ExceptionEnum.java
@@ -5,17 +5,15 @@ import lombok.Getter;
 @Getter
 public enum ExceptionEnum {
 
-/* 로그인 */
+    /* 로그인 */
     // 잘못된 이메일 입니다.
     WRONG_EMAIL(400,"Invalid email."),
     // 잘못된 비밀번호 입니다.
     WORNG_PASSWORD(400,"Invalid password."),
-
     // 유효한 이메일 형식이 아닙니다.
     INVALID_EMAIL_REG(400,"Invalid email format."),
     // 비밀번호는 대소문자, 숫자, 특수문자를 포함하여 8-32자 이내여야 합니다.
     INVALID_PASSWD_REG(400,"Password must be 8-32 characters long, including case, number, and special characters."),
-
     //토큰이 유효하지 않습니다.
     INVALID_TOKEN(400,"Token is not valid."),
     // 잘못된 요청값입니다
@@ -23,7 +21,7 @@ public enum ExceptionEnum {
 
 
 
-/* 계정 권한 */
+    /* 계정 권한 */
     // ADMIN 권한이 필요합니다.
     REQUIRED_ADMIN_POSITION(400, "ADMIN permissions required."),
     // ADMIN 계정으로 직책을 변경할 수 없습니다.
@@ -36,7 +34,7 @@ public enum ExceptionEnum {
     INVALID_PERMISSION_TO_READ(400,"You do not have permission to read."),
 
 
-/* 존재하지 않는 요소 */
+    /* 존재하지 않는 요소 */
     // 해당 직책이 존재하지 않습니다.
     NOT_EXIST_POSITION(400,"The position does not exist."),
     // 해당 계정(사용자)이 존재하지 않습니다.
@@ -52,7 +50,7 @@ public enum ExceptionEnum {
     // 해당 댓글이 존재하지 않습니다.
     NOT_EXIST_COMMENT(400,"The comment does not exist."),
 
-/* 중복 */
+    /* 중복 */
     // 중복된 회사가 존재합니다.
     DUPLICATE_COMPANY(400, "Duplicate company exists."),
     // 중복된 이메일이 존재합니다.
@@ -66,7 +64,7 @@ public enum ExceptionEnum {
     // 중복된 카테고리가 존재합니다.
     DUPLICATE_CATEGORY(400,"Duplicate category exists."),
 
-/* 그 외 */
+    /* 그 외 */
     // 최대 폴더 갯수를 초과하였습니다.
      EXCEED_FOLDER_NUM(400,"Maximum number of folders exceeded");
 

--- a/src/main/java/com/project/comgle/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/comgle/exception/GlobalExceptionHandler.java
@@ -1,20 +1,28 @@
 package com.project.comgle.exception;
 
 import com.project.comgle.dto.common.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
 
 import java.net.UnknownHostException;
+import java.util.Objects;
 
 @RestController
 @ControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
+
     @ExceptionHandler(CustomException.class)
     protected ResponseEntity<ErrorResponse> customException(CustomException e){
+        log.error("CustomException error = {}" , e.getMessage());
         return ResponseEntity.status(e.getExceptionEnum().getCode())
                 .body(ErrorResponse.of(e.getExceptionEnum().getCode(),e.getExceptionEnum().getMsg())
                 );
@@ -22,6 +30,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(UnknownHostException.class)
     protected ResponseEntity<ErrorResponse> customException(UnknownHostException e){
+        log.error("UnknownHostException error = {}" , e.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR.value())
                 .body(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.value(),e.getMessage())
                 );
@@ -29,8 +38,17 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpClientErrorException.class)
     protected ResponseEntity<ErrorResponse> customException(HttpClientErrorException e){
+        log.error("HttpClientErrorException error = {}" , e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND.value())
                 .body(ErrorResponse.of(HttpStatus.NOT_FOUND.value(),e.getMessage())
+                );
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> validException(MethodArgumentNotValidException e){
+        log.error("MethodArgumentNotValidException error msg = {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST.value())
+                .body(ErrorResponse.of(HttpStatus.NOT_FOUND.value(), Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage())
                 );
     }
 }

--- a/src/main/java/com/project/comgle/security/UserDetailsImpl.java
+++ b/src/main/java/com/project/comgle/security/UserDetailsImpl.java
@@ -2,10 +2,13 @@ package com.project.comgle.security;
 
 import com.project.comgle.entity.Company;
 import com.project.comgle.entity.Member;
+import com.project.comgle.entity.enumSet.PositionEnum;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 @Getter
@@ -21,13 +24,14 @@ public class UserDetailsImpl implements UserDetails {
         this.company = company;
     }
 
-    public Member getUser() {
-        return member;
-    }
-
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        PositionEnum position = member.getPosition();
+
+        SimpleGrantedAuthority adminAuthority = new SimpleGrantedAuthority(position.getAuthority());
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(adminAuthority);
+        return authorities;
     }
 
     @Override

--- a/src/main/java/com/project/comgle/service/AdminService.java
+++ b/src/main/java/com/project/comgle/service/AdminService.java
@@ -1,10 +1,13 @@
 package com.project.comgle.service;
 
+import com.project.comgle.dto.common.SuccessResponse;
 import com.project.comgle.dto.request.SignupRequestDto;
 import com.project.comgle.dto.response.MessageResponseDto;
 import com.project.comgle.entity.Company;
 import com.project.comgle.entity.Member;
 import com.project.comgle.entity.enumSet.PositionEnum;
+import com.project.comgle.exception.CustomException;
+import com.project.comgle.exception.ExceptionEnum;
 import com.project.comgle.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -24,33 +27,33 @@ public class AdminService {
 
     // 회원 직책 수정 기능
     @Transactional
-    public MessageResponseDto updatePosition(Long memberId, String pos) {
+    public SuccessResponse updatePosition(Long memberId, String pos) {
 
         PositionEnum position ;
 
         try{
-            position = PositionEnum.valueOf(pos);
+            position = PositionEnum.valueOf(pos.trim().toUpperCase());
         }catch (IllegalArgumentException e){
-            throw new IllegalArgumentException("해당 직책이 존재하지 않습니다.");
+            throw new CustomException(ExceptionEnum.NOT_EXIST_POSITION);
         }
 
         Optional<Member> findMember = memberRepository.findById(memberId);
 
         if( findMember.isEmpty() ){
-            throw new IllegalArgumentException("해당 계정이 존재하지 않습니다.");
+            throw new CustomException(ExceptionEnum.NOT_EXIST_MEMBER);
         } else if (PositionEnum.ADMIN == position){
-            throw new IllegalArgumentException("ADMIN 계정으로 직책을 변경할 수 없습니다.");
+            throw new CustomException(ExceptionEnum.IMMULATABLE_TO_ADMIN);
         } else if(findMember.get().getPosition() == PositionEnum.ADMIN){
-            throw new IllegalStateException("ADMIN 계정은 직책 변경 불가합니다.");
+            throw new CustomException(ExceptionEnum.IMMULATABLE_ADMIN_POSITION);
         }
 
         findMember.get().updatePosition(position);
 
-        return MessageResponseDto.of(HttpStatus.OK.value(), "변경 완료");
+        return SuccessResponse.of(HttpStatus.OK, "변경 완료");
     }
 
     @Transactional
-    public ResponseEntity<MessageResponseDto> signup(SignupRequestDto signupRequestDto, Member member){
+    public SuccessResponse signup(SignupRequestDto signupRequestDto, Member member){
 
         String password = passwordEncoder.encode(signupRequestDto.getPassword());
         PositionEnum position = PositionEnum.valueOf(signupRequestDto.getPosition().trim().toUpperCase());
@@ -58,9 +61,9 @@ public class AdminService {
         Company company = member.getCompany();
 
         if(company == null){
-            throw new IllegalArgumentException("존재하지 않는 회사입니다.");
+            throw new CustomException(ExceptionEnum.NOT_EXIST_COMPANY);
         } else if ( member.getPosition() != PositionEnum.ADMIN) {
-            throw new IllegalArgumentException("ADMIN 권한이 필요합니다");
+            throw new CustomException(ExceptionEnum.REQUIRED_ADMIN_POSITION);
         }
 
         checkName(signupRequestDto.getMemberName(),company);
@@ -68,7 +71,7 @@ public class AdminService {
 
         Member newMember = Member.of(signupRequestDto,password,position,company);
         memberRepository.save(newMember);
-        return ResponseEntity.ok(MessageResponseDto.of(HttpStatus.OK.value(), "회원가입 성공"));
+        return SuccessResponse.of(HttpStatus.OK, "회원가입 성공");
     }
 
     @Transactional(readOnly = true)
@@ -77,9 +80,8 @@ public class AdminService {
         Optional<Member> findMember = memberRepository.findByEmail(email);
 
         if(findMember.isPresent()){
-            throw new IllegalArgumentException("중복된 이메일이 존재합니다.");
+            throw new CustomException(ExceptionEnum.DUPLICATE_EMAIL);
         }
-
     }
 
     @Transactional(readOnly = true)
@@ -88,8 +90,7 @@ public class AdminService {
         Optional<Member> findMember = memberRepository.findByMemberNameAndCompany(memberName, company);
 
         if(findMember.isPresent()){
-            throw new IllegalArgumentException("중복된 사용자명가 존재합니다.");
+            throw new CustomException(ExceptionEnum.DUPLICATE_MEMBER);
         }
-
     }
 }

--- a/src/main/java/com/project/comgle/service/CategoryService.java
+++ b/src/main/java/com/project/comgle/service/CategoryService.java
@@ -1,24 +1,26 @@
 package com.project.comgle.service;
 
+import com.project.comgle.dto.common.SuccessResponse;
 import com.project.comgle.dto.response.CategoryResponseDto;
-import com.project.comgle.dto.response.MessageResponseDto;
 import com.project.comgle.entity.Category;
 import com.project.comgle.entity.Company;
 import com.project.comgle.entity.Member;
 import com.project.comgle.entity.enumSet.PositionEnum;
+import com.project.comgle.exception.CustomException;
+import com.project.comgle.exception.ExceptionEnum;
 import com.project.comgle.repository.CategoryRepository;
 import com.project.comgle.repository.CompanyRepository;
 import com.project.comgle.repository.MemberRepository;
-import com.project.comgle.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -30,21 +32,19 @@ public class CategoryService {
     private final CompanyRepository companyRepository;
 
     @Transactional
-    public MessageResponseDto create(String categoryName, Member member,Company company) {
+    public SuccessResponse create(String categoryName, Member member, Company company) {
 
-        if(member.getPosition() != PositionEnum.ADMIN){
-            throw new IllegalArgumentException("ADMIN 권한이 필요합니다");
-        }
+        isAdmin(member);
 
         Optional<Category> findCategory = categoryRepository.findByCategoryNameAndCompany(categoryName, company);
 
         if(findCategory.isPresent()){
-            throw new IllegalArgumentException("해당 카테고리가 이미 존재 합니다.");
+            throw new CustomException(ExceptionEnum.DUPLICATE_CATEGORY);
         }
 
-        categoryRepository.save(new Category(categoryName, member.getCompany()));
+        categoryRepository.save(Category.of(categoryName, member.getCompany()));
 
-        return MessageResponseDto.of(HttpStatus.OK.value(), "카테고리 추가 완료");
+        return SuccessResponse.of(HttpStatus.OK, "카테고리 추가 완료");
 
     }
 
@@ -52,49 +52,52 @@ public class CategoryService {
     public List<CategoryResponseDto> findCategories(Company company) {
 
         List<Category> categoryList = categoryRepository.findAllByCompany(company);
-        List<CategoryResponseDto> categoryResponseDtos = new ArrayList<>();
 
-        for (Category category : categoryList) {
-            categoryResponseDtos.add(CategoryResponseDto.from(category));
-        }
-
-        return categoryResponseDtos;
+        return categoryList.stream().map(CategoryResponseDto::from).collect(Collectors.toList());
     }
 
     @Transactional
-    public MessageResponseDto updateCategory(Long categoryId, String categoryName, UserDetailsImpl userDetails) {
+    public SuccessResponse updateCategory(Long categoryId, String categoryName, Member member, Company company) {
 
-        Optional<Member> findMember = memberRepository.findById(userDetails.getMember().getId());
+        isAdmin(member);
+
+        Optional<Member> findMember = memberRepository.findById(member.getId());
 
         Category findCategory = categoryRepository.findById(categoryId).orElseThrow(
-                () -> new IllegalStateException("해당 카테고리가 존재하지 않습니다.")
+                () -> new CustomException(ExceptionEnum.NOT_EXIST_CATEGORY)
         );
 
-        if(userDetails.getMember().getPosition() != PositionEnum.ADMIN){
-            throw new IllegalArgumentException("ADMIN 계정만 가능합니다.");
-        } else if (findCategory.getCompany() != findMember.get().getCompany()) {
-            throw new IllegalArgumentException("해당 카테고리를 소유한 회사가 아닙니다.");
+        if (!Objects.equals(findCategory.getCompany().getId(), company.getId())) {
+            throw new CustomException(ExceptionEnum.NOT_EXIST_CATEGORY);
         }
 
         findCategory.update(categoryName.trim());
 
-        return MessageResponseDto.of(HttpStatus.OK.value(),"카테고리 수정 완료");
+        return SuccessResponse.of(HttpStatus.OK,"카테고리 수정 완료");
     }
 
     @Transactional
-    public MessageResponseDto deleteCategory(Long categoryId, Member member) {
+    public SuccessResponse deleteCategory(Long categoryId, Member member, Company company) {
+
+        isAdmin(member);
+
 
         Category findCategory = categoryRepository.findById(categoryId).orElseThrow(
-                () -> new IllegalStateException("해당 카테고리가 존재하지 않습니다.")
+                () -> new CustomException(ExceptionEnum.NOT_EXIST_CATEGORY)
         );
 
-        if(member.getPosition() != PositionEnum.ADMIN){
-            throw new IllegalArgumentException("ADMIN 계정만 가능합니다.");
+        if (!Objects.equals(findCategory.getCompany().getId(), company.getId())) {
+            throw new CustomException(ExceptionEnum.NOT_EXIST_CATEGORY);
         }
 
-//        postCategoryRepository.deleteAllByCategory(findCategory);
         categoryRepository.delete(findCategory);
 
-        return MessageResponseDto.of(HttpStatus.OK.value(), "카테고리 삭제 완료");
+        return SuccessResponse.of(HttpStatus.OK, "카테고리 삭제 완료");
+    }
+
+    private static void isAdmin(Member member) {
+        if(member.getPosition() != PositionEnum.ADMIN){
+            throw new CustomException(ExceptionEnum.REQUIRED_ADMIN_POSITION);
+        }
     }
 }

--- a/src/main/java/com/project/comgle/service/PostService.java
+++ b/src/main/java/com/project/comgle/service/PostService.java
@@ -34,7 +34,7 @@ public class PostService {
         if (findCategory.isEmpty()){
             throw new IllegalArgumentException("카테고리가 유효하지 않습니다.");
         }
-        Post newPost = Post.from(postRequestDto, findCategory.get(),userDetails.getUser());
+        Post newPost = Post.from(postRequestDto, findCategory.get(),userDetails.getMember());
         Set<String> keySet = new HashSet<>(Arrays.asList(postRequestDto.getKeywords()));
 
         for (String k: keySet) {

--- a/src/main/java/com/project/comgle/service/SearchService.java
+++ b/src/main/java/com/project/comgle/service/SearchService.java
@@ -2,7 +2,6 @@ package com.project.comgle.service;
 
 import com.project.comgle.dto.response.SearchResponseDto;
 import com.project.comgle.entity.*;
-import com.project.comgle.exception.ExceptionEnum;
 import com.project.comgle.repository.CategoryRepository;
 import com.project.comgle.repository.CommentRepository;
 import com.project.comgle.repository.KeywordRepository;
@@ -105,6 +104,7 @@ public class SearchService {
 
         List<String> nouns = result.getNouns();
         log.info( "search keywords = {}", String.join(", " , nouns));
+
         return nouns;
     }
 }


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
refactor/105/exception -> develop

### 변경 사항
- 관리자, 카테고리 도메인 예외적용
- 권한부여를 통한 ADMIN 관련 기능 접근제어
- 관리자, 카테고리 도메인 코드 리팩토링(중복 코드 제거, 스트림 적용)
- 카테고리 엔티티 정적 팩토리 메서드 적용
- 직책관련 Enum에 권한 항목 추가
- ExceptionHandler Global 예외로 적용
- UserDetailsImpl getUser() 게터 삭제
- getUser() -> getMember()로 모두 통일 및 적용

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
