### PR TITLE
Fix : 로그1차구현(차선책)_게시글편집일시 수정

### DIFF
--- a/src/main/java/com/project/comgle/entity/Log.java
+++ b/src/main/java/com/project/comgle/entity/Log.java
@@ -5,6 +5,7 @@ import com.project.comgle.security.UserDetailsImpl;
 import lombok.*;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -21,25 +22,23 @@ public class Log {
     private String content;
 
     @Column(nullable = false)
-    private String logModify;
+    private LocalDateTime createDate = LocalDateTime.now();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
     @Builder
-    private Log(String memberName, String content, String logModify, Post post) {
+    private Log(String memberName, String content, Post post) {
         this.memberName = memberName;
         this.content = content;
-        this.logModify = logModify;
         this.post = post;
     }
 
-    public static Log of (String memberName, String content, String logModify, Post post) {
+    public static Log of (String memberName, String content,  Post post) {
         return Log.builder()
                 .memberName(memberName)
                 .content(content)
-                .logModify(logModify)
                 .post(post)
                 .build();
     }

--- a/src/main/java/com/project/comgle/entity/Log.java
+++ b/src/main/java/com/project/comgle/entity/Log.java
@@ -20,21 +20,26 @@ public class Log extends Timestamped {
     @Column(nullable = false)
     private String content;
 
+    @Column(nullable = false)
+    private String logModify;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
     @Builder
-    private Log(String memberName, String content, Post post) {
+    private Log(String memberName, String content, String logModify, Post post) {
         this.memberName = memberName;
         this.content = content;
+        this.logModify = logModify;
         this.post = post;
     }
 
-    public static Log of(Post post, String content, String memberName) {
+    public static Log of (String memberName, String content, String logModify, Post post) {
         return Log.builder()
-                .content(content)
                 .memberName(memberName)
+                .content(content)
+                .logModify(logModify)
                 .post(post)
                 .build();
     }

--- a/src/main/java/com/project/comgle/entity/Log.java
+++ b/src/main/java/com/project/comgle/entity/Log.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Log extends Timestamped {
+public class Log {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/project/comgle/service/PostService.java
+++ b/src/main/java/com/project/comgle/service/PostService.java
@@ -97,8 +97,7 @@ public class PostService {
         findPost.get().update(postRequestDto,findCategory.get());
 
         String content = member.getMemberName() + "님이 해당 페이지를 편집하였습니다.";
-        String logModify = "편집된 시간 : " + findPost.get().getModifiedAt();
-        Log newLog = Log.of (member.getMemberName(), content, logModify, findPost.get());
+        Log newLog = Log.of (member.getMemberName(), content, findPost.get());
         logRepository.save(newLog);
 
         return ResponseEntity.ok().body(MessageResponseDto.of(HttpStatus.OK.value(), "수정 완료"));

--- a/src/main/java/com/project/comgle/service/PostService.java
+++ b/src/main/java/com/project/comgle/service/PostService.java
@@ -97,7 +97,8 @@ public class PostService {
         findPost.get().update(postRequestDto,findCategory.get());
 
         String content = member.getMemberName() + "님이 해당 페이지를 편집하였습니다.";
-        Log newLog = Log.of(findPost.get(), content, member.getMemberName());
+        String logModify = "편집된 시간 : " + findPost.get().getModifiedAt();
+        Log newLog = Log.of (member.getMemberName(), content, logModify, findPost.get());
         logRepository.save(newLog);
 
         return ResponseEntity.ok().body(MessageResponseDto.of(HttpStatus.OK.value(), "수정 완료"));


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
fix/107/log_modifiedAt -> dev

### 변경 사항
- 로그1차구현(차선책)에서 'createdAt', 'modifiedAt'으로 entity table에 들어갔던 부분 -> '편집된 시간 : modifiedAt 일시'로 변경
- Log entity에 extends Timestamped 빼기
- Log.java
- PostService.java

### 테스트 결과
- Postman 테스트 결과 이상 없습니다.
