### PR TITLE
Feat : 편집 상태 구현 (SSE)

### DIFF
--- a/src/main/java/com/project/comgle/controller/SseController.java
+++ b/src/main/java/com/project/comgle/controller/SseController.java
@@ -1,0 +1,22 @@
+package com.project.comgle.controller;
+
+import com.project.comgle.security.UserDetailsImpl;
+import com.project.comgle.service.SseService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class SseController {
+    private final SseService sseService;
+
+    @GetMapping(value = "/connect/{post-id}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subScribe(@PathVariable("post-id") Long postId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return sseService.subscribe(postId, userDetails.getMember().getId());
+    }
+}

--- a/src/main/java/com/project/comgle/dto/common/SchemaDescriptionUtils.java
+++ b/src/main/java/com/project/comgle/dto/common/SchemaDescriptionUtils.java
@@ -27,6 +27,8 @@ public class SchemaDescriptionUtils {
         public static final String TITLE = "제목";
         public static final String CONTENT = "내용";
 
+        public static final String EditingStatus = "편집상태";
+
         public static final String MEDIFY_PERMISSION = "수정권한";
         public static final String READABLE_POSITION = "읽기권한";
     }

--- a/src/main/java/com/project/comgle/dto/request/PostRequestDto.java
+++ b/src/main/java/com/project/comgle/dto/request/PostRequestDto.java
@@ -15,6 +15,9 @@ public class PostRequestDto {
     @Schema(description = SchemaDescriptionUtils.Post.CONTENT,  example = "내용입니다.")
     private String content;
 
+    @Schema(description = SchemaDescriptionUtils.Post.EditingStatus,  example = "편집상태")
+    private String editingStatus;
+
     @Schema(description = SchemaDescriptionUtils.Keyword.NAME)
     private String[] keywords;
 

--- a/src/main/java/com/project/comgle/entity/Post.java
+++ b/src/main/java/com/project/comgle/entity/Post.java
@@ -33,6 +33,10 @@ public class Post extends Timestamped {
     @Column(nullable = false)
     private int score = 0;
 
+    // 편집 중 = true
+    @Column(nullable = false)
+    private String editingStatus = "false";
+
     @Enumerated(EnumType.STRING)
     private PositionEnum modifyPermission;
 
@@ -55,7 +59,7 @@ public class Post extends Timestamped {
     private List<Comment> comments = new ArrayList<>();
 
     @Builder
-    private Post(String title, String content, PositionEnum modifyPermission, PositionEnum readablePosition, Member member,Category category, List<Comment> comments, int postViews, int score) {
+    private Post(String title, String content, PositionEnum modifyPermission, PositionEnum readablePosition, Member member,Category category, List<Comment> comments, int postViews, int score, String editingStatus) {
         this.title = title;
         this.content = content;
         this.modifyPermission = modifyPermission;
@@ -65,12 +69,14 @@ public class Post extends Timestamped {
         this.comments = comments;
         this.postViews = postViews;
         this.score = score;
+        this.editingStatus = editingStatus;
     }
 
     public static Post from(PostRequestDto postRequestDto, Category category,Member member){
         return Post.builder()
                 .title(postRequestDto.getTitle())
                 .content(postRequestDto.getContent())
+                .editingStatus(postRequestDto.getEditingStatus())
                 .modifyPermission(PositionEnum.valueOf(postRequestDto.getModifyPermission().strip().toUpperCase()))
                 .readablePosition(PositionEnum.valueOf(postRequestDto.getReadablePosition().strip().toUpperCase()))
                 .category(category)
@@ -81,12 +87,17 @@ public class Post extends Timestamped {
     public void update(PostRequestDto postRequestDto,Category category) {
         this.title = postRequestDto.getTitle();
         this.content = postRequestDto.getContent();
+        this.editingStatus = "false";
         this.category = category;
     }
 
     public void updateMethod(int weight) {
         this.postViews += (weight==3) ? 1 : 0;
         this.score += weight;
+    }
+
+    public void updateStatus(String editingStatus) {
+        this.editingStatus = editingStatus;
     }
 
 }

--- a/src/main/java/com/project/comgle/entity/SseEmitters.java
+++ b/src/main/java/com/project/comgle/entity/SseEmitters.java
@@ -1,0 +1,27 @@
+package com.project.comgle.entity;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Getter
+@Component
+@Slf4j
+public class SseEmitters {
+    private Map<Long, SseEmitter> sseEmitters = new ConcurrentHashMap<>();
+
+    public SseEmitter subscribeMember(Long memberId) {
+        SseEmitter sseEmitter = new SseEmitter(1000L * 60 * 60);
+        sseEmitters.put(memberId, sseEmitter);
+
+        sseEmitter.onCompletion(() -> sseEmitters.remove(memberId));
+        sseEmitter.onTimeout(() -> sseEmitters.remove(memberId));
+
+        return sseEmitter;
+    }
+
+}

--- a/src/main/java/com/project/comgle/repository/EmitterRepository.java
+++ b/src/main/java/com/project/comgle/repository/EmitterRepository.java
@@ -1,0 +1,21 @@
+package com.project.comgle.repository;
+
+import com.project.comgle.entity.SseEmitters;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class EmitterRepository {
+    public static Map<Long, SseEmitters> postSseEmitters = new ConcurrentHashMap<>();
+
+    public SseEmitters subscibePosts(Long postId) {
+        if (postSseEmitters.get(postId) == null) {
+            SseEmitters postSseEmittersMap = new SseEmitters();
+            postSseEmitters.put(postId, postSseEmittersMap);
+        }
+
+        return postSseEmitters.get(postId);
+    }
+}

--- a/src/main/java/com/project/comgle/service/SseService.java
+++ b/src/main/java/com/project/comgle/service/SseService.java
@@ -1,0 +1,41 @@
+package com.project.comgle.service;
+
+import com.project.comgle.entity.Post;
+import com.project.comgle.entity.SseEmitters;
+import com.project.comgle.repository.EmitterRepository;
+import com.project.comgle.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SseService {
+    private final EmitterRepository emitterRepository;
+    private final PostRepository postRepository;
+
+    public SseEmitter subscribe(Long postId, Long memberId) {
+
+        Optional<Post> findPosts = postRepository.findById(postId);
+        if (findPosts.isEmpty()) {
+            throw new IllegalArgumentException("해당 게시글이 없습니다.");
+        }
+
+        SseEmitters postEmitters = emitterRepository.subscibePosts(postId);
+        SseEmitter memberEmitter = postEmitters.subscribeMember(memberId);
+
+        try {
+            memberEmitter.send(SseEmitter.event().name(findPosts.get().getEditingStatus()));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        findPosts.get().updateStatus("true"); // true = 수정 중
+        postRepository.save(findPosts.get());
+
+        return memberEmitter;
+    }
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/67/editing-status-> develop

### 변경 사항
- 여러 멤버(sseEmitter)가 한 게시글에 대해 편집 상태 변경 -> 여러 게시글에 sse 동시에 돌아가도록 구현
- Post에 편집 상태 나타내는 editingStatus 칼럼 추가

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
