### PR TITLE
Feat : Naver SMS로 문자인증 구현 (#114)

### DIFF
--- a/src/main/java/com/project/comgle/config/WebSecurityConfig.java
+++ b/src/main/java/com/project/comgle/config/WebSecurityConfig.java
@@ -66,6 +66,8 @@ public class WebSecurityConfig {
         http.authorizeRequests() //  요청에 대한 보안 검사를 구성한다.
                 .antMatchers("/login").permitAll()
                 .antMatchers("/check/**").permitAll()
+                .antMatchers("/member/email").permitAll()
+                .antMatchers("/sms").permitAll()
                 .anyRequest().authenticated() // 나머지 URL에 대한 접근 권한을 설정합니다. 인증된 사용자만 접근할 수 있다.
                 // JWT 인증/인가를 사용하기 위한 설정
                 // JwtAuthFilter를 UsernamePasswordAuthenticationFilter 이전에 실행되도록 설정한다. JwtAuthFilter는 JWT 토큰을 검증하고 인증/인가를 처리한다.

--- a/src/main/java/com/project/comgle/controller/LogController.java
+++ b/src/main/java/com/project/comgle/controller/LogController.java
@@ -5,7 +5,6 @@ import com.project.comgle.security.UserDetailsImpl;
 import com.project.comgle.service.LogService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/com/project/comgle/controller/MemberController.java
+++ b/src/main/java/com/project/comgle/controller/MemberController.java
@@ -1,6 +1,5 @@
 package com.project.comgle.controller;
 
-import com.project.comgle.dto.common.ErrorResponse;
 import com.project.comgle.dto.request.CompanyRequestDto;
 import com.project.comgle.dto.request.LoginRequestDto;
 import com.project.comgle.dto.response.MemberResponseDto;
@@ -14,8 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
@@ -50,4 +47,5 @@ public class MemberController {
     public List<MemberResponseDto> getMembers(@AuthenticationPrincipal UserDetailsImpl userDetails){
         return memberService.findMembers(userDetails.getMember());
     }
+
 }

--- a/src/main/java/com/project/comgle/dto/common/SchemaDescriptionUtils.java
+++ b/src/main/java/com/project/comgle/dto/common/SchemaDescriptionUtils.java
@@ -4,8 +4,8 @@ public class SchemaDescriptionUtils {
 
     public static final String ID = "고유번호";
     public static final String EMAIL = "이메일";
-    public static final String CREATE_AT = "이메일";
-    public static final String MODIFIED_AT = "이메일";
+    public static final String CREATE_AT = "생성일자";
+    public static final String MODIFIED_AT = "수정일자";
     public static final String STATUS_CODE = "상태코드";
     public static final String MESSAGE = "상태메세지";
 
@@ -20,6 +20,7 @@ public class SchemaDescriptionUtils {
     public static class Member {
         public static final String NAME = "회원명";
         public static final String PASSWORD = "패스워드";
+        public static final String TEL = "연락처";
         public static final String POSITION = "직책(MEMBER|MANAGER|OWNER)";
     }
 
@@ -45,5 +46,9 @@ public class SchemaDescriptionUtils {
 
     public static class BookMarkForder{
         public static final String NAME = "카테고리명";
+    }
+
+    public static class SMS{
+        public static final String AUTHENTICATION_CODE = "SMS 인증코드(6자리)";
     }
 }

--- a/src/main/java/com/project/comgle/dto/request/FindEmailRequestDto.java
+++ b/src/main/java/com/project/comgle/dto/request/FindEmailRequestDto.java
@@ -1,0 +1,30 @@
+package com.project.comgle.dto.request;
+
+import com.project.comgle.dto.common.SchemaDescriptionUtils;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FindEmailRequestDto {
+
+    @NotNull(message = "회원명은 필수 값입니다.")
+    @Schema(description = SchemaDescriptionUtils.Member.NAME, example = "회원명" , maxLength = 20)
+    private String memberName;
+
+    @NotNull(message = "연락처는 필수 값입니다.")
+    @Schema(description = SchemaDescriptionUtils.Member.TEL, example = "010-xxxx-xxxx")
+    @Pattern(regexp = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$" , message = "올바르지 않은 연락처 형식입니다.")
+    private String phoneNum;
+
+    @NotNull(message = "인증코드가 없습니다.")
+    @Schema(description = SchemaDescriptionUtils.SMS.AUTHENTICATION_CODE, example = "xxxxxx")
+    private int authenticationCode;
+
+}

--- a/src/main/java/com/project/comgle/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/project/comgle/dto/request/SignupRequestDto.java
@@ -2,12 +2,14 @@ package com.project.comgle.dto.request;
 
 import com.project.comgle.dto.common.SchemaDescriptionUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 @Getter
+@AllArgsConstructor
 public class SignupRequestDto {
 
     @NotNull(message = "회원명은 필수 값입니다.")
@@ -28,5 +30,9 @@ public class SignupRequestDto {
     @Schema(description = SchemaDescriptionUtils.Member.POSITION, example = "MEMBER",  allowableValues = {"MEMEBER", "MANAGER","OWNER"})
     private String position;
 
+    @NotNull(message = "연락처는 필수 값입니다.")
+    @Schema(description = SchemaDescriptionUtils.Member.TEL, example = "010-xxxx-xxxx")
+    @Pattern(regexp = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$" , message = "올바르지 않은 연락처 형식입니다.")
+    private String phoneNum;
 
 }

--- a/src/main/java/com/project/comgle/entity/Member.java
+++ b/src/main/java/com/project/comgle/entity/Member.java
@@ -26,6 +26,9 @@ public class Member {
     @Column(nullable = false)
     private String password;
 
+    @Column(nullable = false, length = 20)
+    private String phoneNum;
+
     @Enumerated(EnumType.STRING)
     private PositionEnum position;
 
@@ -34,31 +37,26 @@ public class Member {
     private Company company;
 
     @Builder
-    private Member(String memberName, String email, String password, PositionEnum position, Company company) {
+    private Member(String memberName, String email, String password,
+                   PositionEnum position, Company company, String phoneNum) {
         this.memberName = memberName;
         this.email = email;
         this.password = password;
         this.position = position;
         this.company = company;
+        this.phoneNum = phoneNum;
     }
 
-    public static Member of(SignupRequestDto signupRequestDto, String password, PositionEnum position, Company company) {
+
+    public static Member of(SignupRequestDto signupRequestDto, String password,
+                            PositionEnum position, Company company) {
         return Member.builder()
                 .memberName(signupRequestDto.getMemberName())
                 .email(signupRequestDto.getEmail())
                 .password(password)
                 .position(position)
                 .company(company)
-                .build();
-    }
-
-    public static Member of(String memberName, String email, String password, PositionEnum position, Company company) {
-        return Member.builder()
-                .memberName(memberName)
-                .email(email)
-                .password(password)
-                .position(position)
-                .company(company)
+                .phoneNum(signupRequestDto.getPhoneNum())
                 .build();
     }
 

--- a/src/main/java/com/project/comgle/exception/ExceptionEnum.java
+++ b/src/main/java/com/project/comgle/exception/ExceptionEnum.java
@@ -18,6 +18,12 @@ public enum ExceptionEnum {
     INVALID_TOKEN(400,"Token is not valid."),
     // 잘못된 요청값입니다
     INVALID_VALUE(400,"Invalid request value."),
+    // SMS 전송 에러발생입니다.
+    SMS_SEND_ERR(400,"fail send sms message"),
+    // SMS 전송 에러발생입니다.
+    INVALID_AUTHENTICATION_CODE(400,"Invalid authentication code"),
+    // SMS 인증한 내역이 없을경우
+    NOT_EXIST_AUTHENTICATION_CODE(400," Not exist authentication code"),
 
 
 

--- a/src/main/java/com/project/comgle/repository/MemberRepository.java
+++ b/src/main/java/com/project/comgle/repository/MemberRepository.java
@@ -14,6 +14,11 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
 
     Optional<Member> findByMemberNameAndCompany(String memberName,Company company);
 
+    Optional<Member> findByMemberNameStartingWithAndPhoneNum(String memberName, String phoneNum);
+
+    Optional<Member> findByPhoneNum(String phoneNum);
+
     List<Member> findAllByCompany(Company company);
+
 
 }

--- a/src/main/java/com/project/comgle/scheduler/Scheduler.java
+++ b/src/main/java/com/project/comgle/scheduler/Scheduler.java
@@ -1,0 +1,28 @@
+package com.project.comgle.scheduler;
+
+import com.project.comgle.sms.service.SmsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class Scheduler {
+
+    private final SmsService smsService;
+
+    // 초(0-59) / 분(0-59) / 시(0-23) / 일(1-31) / 월(1-12) / 요일(0-6 or SUN-SAT)
+    // 요일 - 0, 7 : 일요일
+    @Scheduled(cron = "0 0 0 * * 1-5")
+    public void clearSmsCode() throws InterruptedException {
+        log.info("Current Time : {} SMS 인증 관리 Map 초기화 실행 " , LocalDateTime.now());
+        smsService.clearSmsCode();
+    }
+
+}
+

--- a/src/main/java/com/project/comgle/service/AdminService.java
+++ b/src/main/java/com/project/comgle/service/AdminService.java
@@ -2,7 +2,6 @@ package com.project.comgle.service;
 
 import com.project.comgle.dto.common.SuccessResponse;
 import com.project.comgle.dto.request.SignupRequestDto;
-import com.project.comgle.dto.response.MessageResponseDto;
 import com.project.comgle.entity.Company;
 import com.project.comgle.entity.Member;
 import com.project.comgle.entity.enumSet.PositionEnum;
@@ -11,7 +10,6 @@ import com.project.comgle.exception.ExceptionEnum;
 import com.project.comgle.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/project/comgle/service/MemberService.java
+++ b/src/main/java/com/project/comgle/service/MemberService.java
@@ -2,6 +2,7 @@ package com.project.comgle.service;
 
 import com.project.comgle.dto.request.CompanyRequestDto;
 import com.project.comgle.dto.request.LoginRequestDto;
+import com.project.comgle.dto.request.SignupRequestDto;
 import com.project.comgle.dto.response.MemberResponseDto;
 import com.project.comgle.dto.response.MessageResponseDto;
 import com.project.comgle.entity.Company;
@@ -31,20 +32,6 @@ public class MemberService {
     private final CompanyRepository companyRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
-
-    // 개발 단계용
-    @PostConstruct
-    @Transactional
-    public void init(){
-        List<Company> companyList = new ArrayList<>();
-        List<Member> adminList = new ArrayList<>();
-        companyList.add(Company.of("삼성","논현동","02-111-1111","이재용","123-45-67890","samsung@samsung.com"));
-        companyList.add(Company.of("애플","벨리","02-111-1111","잡슨","123-45-67890","apple@apple.com"));
-        companyRepository.saveAll(companyList);
-        adminList.add(Member.of("삼성ADMIN","admin@samsung.com",passwordEncoder.encode("1234"),PositionEnum.ADMIN,companyList.get(0)));
-        adminList.add(Member.of("애플ADMIN","admin@apple.com",passwordEncoder.encode("1234"),PositionEnum.ADMIN,companyList.get(1)));
-        memberRepository.saveAll(adminList);
-    }
 
     @Transactional
     public ResponseEntity<MessageResponseDto> companyAdd(CompanyRequestDto companyRequestDto){
@@ -94,4 +81,5 @@ public class MemberService {
 
         return memberResponseDtos;
     }
+
 }

--- a/src/main/java/com/project/comgle/sms/controller/SmsController.java
+++ b/src/main/java/com/project/comgle/sms/controller/SmsController.java
@@ -1,0 +1,45 @@
+package com.project.comgle.sms.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.project.comgle.dto.request.FindEmailRequestDto;
+import com.project.comgle.sms.dto.SmsResponseDto;
+import com.project.comgle.sms.service.SmsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "SMS", description = "SMS 전송 API Document")
+public class SmsController {
+
+    private final SmsService smsService;
+
+    @Operation(summary = "SMS 코드 발송 API", description = "Email과 연락처를 통해서 유효한 회원인지 확인 후 SMS 코드를 발송 합니다.")
+    @ResponseStatus(value = HttpStatus.OK)
+    @PostMapping("/sms")
+    public ResponseEntity<SmsResponseDto> sendSmsCode(@RequestBody FindEmailRequestDto emailCheckRequestDto) {
+        return smsService.sendSmsCode(emailCheckRequestDto);
+    }
+
+    @Operation(summary = "회원 Email 찾기 API", description = "SMS 코드 확인 후 EMAIL을 발송합니다.")
+    @ResponseStatus(value = HttpStatus.OK)
+    @PostMapping("/member/email")
+    public  ResponseEntity<Map<String,String>> findEmail(@RequestBody FindEmailRequestDto emailCheckRequestDto) {
+        return smsService.findEmail(emailCheckRequestDto);
+    }
+
+
+}

--- a/src/main/java/com/project/comgle/sms/dto/MessageDto.java
+++ b/src/main/java/com/project/comgle/sms/dto/MessageDto.java
@@ -1,0 +1,26 @@
+package com.project.comgle.sms.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MessageDto {
+
+    String to;
+
+    String content;
+
+    public static MessageDto of(String to, String content){
+        return MessageDto.builder()
+                .to(to)
+                .content(content)
+                .build();
+    }
+
+}

--- a/src/main/java/com/project/comgle/sms/dto/SmsRequestDto.java
+++ b/src/main/java/com/project/comgle/sms/dto/SmsRequestDto.java
@@ -1,0 +1,44 @@
+package com.project.comgle.sms.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SmsRequestDto {
+
+    String type;
+
+    String contentType;
+
+    String countryCode;
+
+    String subject;
+
+    String from;
+
+    String content;
+
+    List<MessageDto> messages;
+
+    public static SmsRequestDto of(String type, String contentType, String countryCode,String subject,
+                                   String from, String content, List<MessageDto> messages){
+
+        return SmsRequestDto.builder()
+                .type(type)
+                .contentType(contentType)
+                .countryCode(countryCode)
+                .subject(subject)
+                .from(from)
+                .content(content)
+                .messages(messages)
+                .build();
+
+    }
+}

--- a/src/main/java/com/project/comgle/sms/dto/SmsResponseDto.java
+++ b/src/main/java/com/project/comgle/sms/dto/SmsResponseDto.java
@@ -1,0 +1,34 @@
+package com.project.comgle.sms.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SmsResponseDto {
+
+    private String requestId;
+
+    private LocalDateTime requestTime;
+
+    private String statusCode;
+
+    private String statusName;
+
+    @Setter
+    private String phoneNum;
+
+    public static SmsResponseDto of(String requestId, LocalDateTime requestTime, String statusCode, String statusName){
+        return SmsResponseDto.builder()
+                .requestId(requestId)
+                .requestTime(requestTime)
+                .statusCode(statusCode)
+                .statusName(statusName)
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/project/comgle/sms/service/SmsService.java
+++ b/src/main/java/com/project/comgle/sms/service/SmsService.java
@@ -1,0 +1,185 @@
+package com.project.comgle.sms.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.comgle.dto.request.FindEmailRequestDto;
+import com.project.comgle.entity.Member;
+import com.project.comgle.exception.CustomException;
+import com.project.comgle.exception.ExceptionEnum;
+import com.project.comgle.repository.MemberRepository;
+import com.project.comgle.sms.dto.MessageDto;
+import com.project.comgle.sms.dto.SmsRequestDto;
+import com.project.comgle.sms.dto.SmsResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SmsService {
+
+    private final MemberRepository memberRepository;
+    private static final Map<String,Integer> smsCodeMap = new ConcurrentHashMap<>();
+
+    // 환경변수 설정
+    @Value("${naver-cloud-sms.accessKey}")
+    private String accessKey;
+
+    @Value("${naver-cloud-sms.secretKey}")
+    private String secretKey;
+
+    @Value("${naver-cloud-sms.serviceId}")
+    private String serviceId;
+
+    @Value("${naver-cloud-sms.senderPhone}")
+    private String phone;
+
+    @Transactional(readOnly = true)
+    public ResponseEntity<SmsResponseDto> sendSmsCode(FindEmailRequestDto emailCheckRequestDto) {
+
+        Member findMember = memberRepository.findByMemberNameStartingWithAndPhoneNum(emailCheckRequestDto.getMemberName(),
+                emailCheckRequestDto.getPhoneNum()).orElseThrow(
+                () -> new CustomException(ExceptionEnum.NOT_EXIST_MEMBER)
+        );
+
+        int authenticationCode = new Random().nextInt(900000)+100000;
+
+        SmsResponseDto smsResponseDto ;
+        try {
+            smsResponseDto = sendSms(MessageDto.of( findMember.getPhoneNum().replaceAll("-", ""), "[knock 본인인증] " + authenticationCode ));
+            smsResponseDto.setPhoneNum(findMember.getPhoneNum());
+        } catch (IOException | URISyntaxException | InvalidKeyException | NoSuchAlgorithmException e) {
+            throw new CustomException(ExceptionEnum.SMS_SEND_ERR);
+        }
+        smsCodeMap.put(findMember.getPhoneNum(), authenticationCode);
+        log.info("smsCodeMap size = {}", smsCodeMap.size());
+
+        return ResponseEntity.ok()
+                .body(smsResponseDto);
+
+    }
+
+    @Transactional(readOnly = true)
+    public ResponseEntity<Map<String, String>> findEmail(FindEmailRequestDto emailCheckRequestDto) {
+
+        Member findMember = memberRepository.findByPhoneNum(emailCheckRequestDto.getPhoneNum()).orElseThrow(
+                () -> new CustomException(ExceptionEnum.NOT_EXIST_MEMBER)
+        );
+
+        int findAuthenticationCode = Optional.ofNullable(smsCodeMap.get(findMember.getPhoneNum())).orElseThrow(
+                () -> new CustomException(ExceptionEnum.NOT_EXIST_AUTHENTICATION_CODE)
+        );
+
+        if(findAuthenticationCode != emailCheckRequestDto.getAuthenticationCode()){
+            throw new CustomException(ExceptionEnum.INVALID_AUTHENTICATION_CODE);
+        }
+
+        Map<String, String> findEmail = new HashMap<>();
+        findEmail.put("email", findMember.getEmail());
+        smsCodeMap.remove(findMember.getPhoneNum());
+
+        return ResponseEntity.ok().body(findEmail);
+    }
+    // Signature 필드 값 생성을 위한 메서드
+    public String makeSignature(Long time) throws NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
+        // one space
+        String space = " ";
+        // new line
+        String newLine = "\n";
+        // method
+        String method = "POST";
+        // url (include query string)
+        String url = "/sms/v2/services/"+ this.serviceId + "/messages";
+        // current timestamp (epoch)
+        String timestamp = time.toString();
+        // access key id (from portal or Sub Account)
+        String accessKey = this.accessKey;
+        String secretKey = this.secretKey;
+
+        String message = new StringBuilder()
+                .append(method)
+                .append(space)
+                .append(url)
+                .append(newLine)
+                .append(timestamp)
+                .append(newLine)
+                .append(accessKey)
+                .toString();
+
+        // secretKey HMAC 암호화 알고리즘 암호화
+        SecretKeySpec signingKey = new SecretKeySpec(secretKey.getBytes("UTF-8"), "HmacSHA256");
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(signingKey);
+
+
+        byte[] rawHmac = mac.doFinal(message.getBytes("UTF-8"));
+        String encodeBase64String = Base64.encodeBase64String(rawHmac);
+
+        return encodeBase64String;
+    }
+
+    // 메세지 발송 메서드
+    private SmsResponseDto sendSms(MessageDto messageDto) throws JsonProcessingException, RestClientException, URISyntaxException, InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
+
+        // NAVER SMS Service를 활용하기 위한 요청 Header
+        Long time = System.currentTimeMillis();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("x-ncp-apigw-timestamp", time.toString());
+        headers.set("x-ncp-iam-access-key", accessKey);
+        headers.set("x-ncp-apigw-signature-v2", makeSignature(time));
+
+        // 인증코드 발송을 위한 인증코드 생성
+        List<MessageDto> messages = new ArrayList<>();
+        messages.add(messageDto);
+
+        SmsRequestDto request = SmsRequestDto.of("LMS","COMM","82","[knock 본인인증]",
+                phone, messageDto.getContent(), messages);
+
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String body = objectMapper.writeValueAsString(request);
+        HttpEntity<String> httpBody = new HttpEntity<>(body, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+        SmsResponseDto response = restTemplate.postForObject(new URI("https://sens.apigw.ntruss.com/sms/v2/services/"+ serviceId +"/messages"), httpBody, SmsResponseDto.class);
+
+        if(Objects.isNull(response)){
+            throw new CustomException(ExceptionEnum.SMS_SEND_ERR);
+        }
+
+        return response;
+    }
+
+    public void clearSmsCode(){
+        log.info("before smsCodeMap size = {}", smsCodeMap.size());
+        smsCodeMap.clear();
+        log.info("Current Time : {} - Success smsCodeMap Clear ", LocalTime.now());
+    }
+
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/114/sms -> develop

### 변경 사항
- Naver cloud flaform SMS 서비스 등록
- Member 엔티티 phoneNum 연락처 항목 추가
- 이메일 찾기 시 회원명 + 연락처로 회원 존재 여부 확인
- 확인 시 해당 연락처로 SMS 인증 코드 6자리 발송
- 해당 인증 코드 확인 후 해당 회원 Email 반환
- 스케줄러를 통해 0시 Sms 관리 Map 초기화

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
